### PR TITLE
Add relative jog OSC command + Hold on Pause toggle for LTC Out

### DIFF
--- a/AppSettings.h
+++ b/AppSettings.h
@@ -1183,6 +1183,7 @@ struct EngineSettings
     int ltcInputGain = 100;
     int thruInputGain = 100;
     int ltcOutputGain = 100;
+    bool ltcHoldOnPause = false;
     int thruOutputGain = 100;
 
     // Audio BPM detection (for non-DJ sources)
@@ -1284,6 +1285,7 @@ struct EngineSettings
         obj->setProperty("ltcInputGain", ltcInputGain);
         obj->setProperty("thruInputGain", thruInputGain);
         obj->setProperty("ltcOutputGain", ltcOutputGain);
+        obj->setProperty("ltcHoldOnPause", ltcHoldOnPause);
         obj->setProperty("thruOutputGain", thruOutputGain);
 
         obj->setProperty("audioBpmEnabled", audioBpmEnabled);
@@ -1412,6 +1414,7 @@ struct EngineSettings
         ltcInputGain   = clampGain(getInt("ltcInputGain", 100));
         thruInputGain  = clampGain(getInt("thruInputGain", 100));
         ltcOutputGain  = clampGain(getInt("ltcOutputGain", 100));
+        ltcHoldOnPause = getBool("ltcHoldOnPause", false);
         thruOutputGain = clampGain(getInt("thruOutputGain", 100));
 
         audioBpmEnabled  = getBool("audioBpmEnabled", false);
@@ -1695,6 +1698,7 @@ private:
         es.ltcInputGain   = clampGain(getInt("ltcInputGain", 100));
         es.thruInputGain  = clampGain(getInt("thruInputGain", 100));
         es.ltcOutputGain  = clampGain(getInt("ltcOutputGain", 100));
+        es.ltcHoldOnPause = getBool("ltcHoldOnPause", false);
         es.thruOutputGain = clampGain(getInt("thruOutputGain", 100));
 
         es.audioBpmEnabled  = getBool("audioBpmEnabled", false);

--- a/LtcOutput.h
+++ b/LtcOutput.h
@@ -122,6 +122,9 @@ public:
     }
     bool isPaused() const             { return paused.load(std::memory_order_relaxed); }
 
+    void setHoldOnPause(bool h)       { holdOnPause.store(h, std::memory_order_relaxed); }
+    bool getHoldOnPause() const       { return holdOnPause.load(std::memory_order_relaxed); }
+
     void setOutputGain(float gain)    { outputGain.store(juce::jlimit(0.0f, 2.0f, gain), std::memory_order_relaxed); }
     float getOutputGain() const       { return outputGain.load(std::memory_order_relaxed); }
 
@@ -144,6 +147,7 @@ private:
     std::atomic<uint64_t> packedPendingTc { 0 };
     std::atomic<FrameRate> pendingFps { FrameRate::FPS_25 };
     std::atomic<bool> paused { false };
+    std::atomic<bool> holdOnPause { false };
     std::atomic<float> outputGain { 1.0f };
     std::atomic<float> peakLevel { 0.0f };
     std::atomic<double> pitchMultiplier { 1.0 };
@@ -307,7 +311,7 @@ private:
             if (outputChannelData[ch])
                 std::memset(outputChannelData[ch], 0, sizeof(float) * (size_t)numSamples);
 
-        if (paused.load(std::memory_order_relaxed))
+        if (paused.load(std::memory_order_relaxed) && !holdOnPause.load(std::memory_order_relaxed))
             return;
 
         int selCh = selectedChannel.load(std::memory_order_relaxed);

--- a/MainComponent.cpp
+++ b/MainComponent.cpp
@@ -1690,6 +1690,16 @@ MainComponent::MainComponent()
     rightContent.addAndMakeVisible(mtrLtcOutput); mtrLtcOutput.setMeterColour(accentPurple);
     sldLtcOutputGain.onValueChange = [this] { if (!syncing) { currentEngine().getLtcOutput().setOutputGain((float)sldLtcOutputGain.getValue() / 100.0f); saveSettings(); } };
 
+    rightContent.addAndMakeVisible(btnLtcHoldOnPause);
+    styleOutputToggle(btnLtcHoldOnPause, accentPurple);
+    btnLtcHoldOnPause.onClick = [this]
+    {
+        if (syncing) return;
+        if (isShowLocked()) { btnLtcHoldOnPause.setToggleState(!btnLtcHoldOnPause.getToggleState(), juce::dontSendNotification); return; }
+        currentEngine().getLtcOutput().setHoldOnPause(btnLtcHoldOnPause.getToggleState());
+        saveSettings();
+    };
+
     rightContent.addAndMakeVisible(lblOutputLtcStatus); styleLabel(lblOutputLtcStatus); lblOutputLtcStatus.setColour(juce::Label::textColourId, accentPurple);
     rightContent.addAndMakeVisible(sldLtcOffset); styleOffsetSlider(sldLtcOffset);
     rightContent.addAndMakeVisible(lblLtcOffset); lblLtcOffset.setText("LTC OFFSET:", juce::dontSendNotification); styleLabel(lblLtcOffset);
@@ -2247,6 +2257,7 @@ void MainComponent::syncUIFromEngine()
         sldLtcInputGain.setValue(eng.getLtcInput().getInputGain() * 100.0f, juce::dontSendNotification);
     sldThruInputGain.setValue(eng.getLtcInput().getPassthruGain() * 100.0f, juce::dontSendNotification);
     sldLtcOutputGain.setValue(eng.getLtcOutput().getOutputGain() * 100.0f, juce::dontSendNotification);
+    btnLtcHoldOnPause.setToggleState(eng.getLtcOutput().getHoldOnPause(), juce::dontSendNotification);
     if (eng.getAudioThru())
         sldThruOutputGain.setValue(eng.getAudioThru()->getOutputGain() * 100.0f, juce::dontSendNotification);
 
@@ -4181,6 +4192,7 @@ void MainComponent::loadAndApplyNonAudioSettings()
         eng.getLtcInput().setInputGain((float)es.ltcInputGain / 100.0f);
         eng.getLtcInput().setPassthruGain((float)es.thruInputGain / 100.0f);
         eng.getLtcOutput().setOutputGain((float)es.ltcOutputGain / 100.0f);
+        eng.getLtcOutput().setHoldOnPause(es.ltcHoldOnPause);
         if (eng.getAudioThru())
             eng.getAudioThru()->setOutputGain((float)es.thruOutputGain / 100.0f);
 
@@ -4526,6 +4538,7 @@ void MainComponent::flushSettings()
         es.ltcInputGain = (int)(eng.getLtcInput().getInputGain() * 100.0f);
         es.thruInputGain = (int)(eng.getLtcInput().getPassthruGain() * 100.0f);
         es.ltcOutputGain = (int)(eng.getLtcOutput().getOutputGain() * 100.0f);
+        es.ltcHoldOnPause = eng.getLtcOutput().getHoldOnPause();
         if (eng.getAudioThru())
             es.thruOutputGain = (int)(eng.getAudioThru()->getOutputGain() * 100.0f);
 
@@ -5278,6 +5291,7 @@ void MainComponent::updateDeviceSelectorVisibility()
     cmbAudioOutputDevice.setVisible(showLtcConfig);  lblAudioOutputDevice.setVisible(showLtcConfig);
     cmbAudioOutputChannel.setVisible(showLtcConfig); lblAudioOutputChannel.setVisible(showLtcConfig);
     sldLtcOutputGain.setVisible(showLtcConfig);      lblLtcOutputGain.setVisible(showLtcConfig);
+    btnLtcHoldOnPause.setVisible(showLtcConfig);
     mtrLtcOutput.setVisible(showLtcConfig);
     sldLtcOffset.setVisible(showLtcConfig);            lblLtcOffset.setVisible(showLtcConfig);
     lblOutputLtcStatus.setVisible(eng.isOutputLtcEnabled());
@@ -5674,6 +5688,15 @@ void MainComponent::setupOscInputServer()
             else if (cmd == "/stc/gen/pause")
             {
                 eng.generatorPause();
+            }
+            else if (cmd == "/stc/gen/jog")
+            {
+                float deltaSec = msg.getFloat(0, 0.0f);
+                if (deltaSec != 0.0f)
+                {
+                    double newMs = eng.getGeneratorCurrentMs() + (double)deltaSec * 1000.0;
+                    eng.setGeneratorPosition(newMs);
+                }
             }
             else if (cmd == "/stc/gen/stop")
             {
@@ -6806,6 +6829,7 @@ void MainComponent::resized()
             layCombo(lblAudioOutputDevice, cmbAudioOutputDevice, rp);
             layCombo(lblAudioOutputChannel, cmbAudioOutputChannel, rp);
             laySlider(lblLtcOutputGain, sldLtcOutputGain, rp);
+            if (btnLtcHoldOnPause.isVisible()) btnLtcHoldOnPause.setBounds(rp.removeFromTop(btnH));
             if (mtrLtcOutput.isVisible()) layMeter(mtrLtcOutput, rp);
             if (sldLtcOffset.isVisible()) laySlider(lblLtcOffset, sldLtcOffset, rp);
         }

--- a/MainComponent.h
+++ b/MainComponent.h
@@ -540,6 +540,7 @@ private:
     juce::ComboBox cmbAudioOutputDevice;     juce::Label lblAudioOutputDevice;
     juce::ComboBox cmbAudioOutputChannel;    juce::Label lblAudioOutputChannel;
     GainSlider sldLtcOutputGain;             juce::Label lblLtcOutputGain;
+    juce::ToggleButton btnLtcHoldOnPause { "HOLD ON PAUSE" };
     LevelMeter mtrLtcOutput;
     juce::ComboBox cmbThruOutputDevice;      juce::Label lblThruOutputDevice;
     juce::ComboBox cmbThruOutputChannel;     juce::Label lblThruOutputChannel;


### PR DESCRIPTION
## Summary

Two small additions to the Generator/LTC Out, both aimed at live
programming workflows (e.g. a lighting programmer jogging back/forward
through a cue while STC drives LTC to a console via Bitfocus Companion):

- **`/stc/N/gen/jog <seconds>`** — a new OSC command that performs a
  *relative* seek (positive = forward, negative = back), reusing the
  existing `TimecodeEngine::setGeneratorPosition()` /
  `getGeneratorCurrentMs()` (no engine changes needed — these already
  handle audio-file lockstep seeking and cue-cursor resync correctly).
  Unlike `/stc/gen/stop`, this preserves Playing/Paused state rather than
  resetting to Start TC, so it behaves like a jog wheel rather than a
  cue-and-restart.
- **"Hold on Pause" toggle** (LTC Out panel, default **off** — matches
  current behavior) — when enabled, LTC output keeps encoding the frozen
  timecode instead of going silent while the generator is paused, so
  downstream LTC receivers see continuous signal rather than a dropout
  during a jog/pause. Persisted per-engine like the other LTC Out settings.

## Scope

Four files touched, nothing else: `MainComponent.cpp`, `MainComponent.h`,
`LtcOutput.h`, `AppSettings.h`. Followed existing patterns throughout
(`styleOutputToggle`, the `getBool`/settings save-load-per-engine-copy
triplet, the `setPaused`/`isPaused` atomic style, Show Lock gating on the
new toggle, etc.) rather than introducing new conventions.

## ⚠️ Not build-tested

I don't have the Projucer project file or the vendor SDKs (Pro DJ Link,
StageLinQ, BTT) that are gitignored in this repo, so I could not compile
or run this locally. The diff was written and then manually re-verified
line-by-line against the actual source (confirmed every referenced symbol
— `btnH`, `accentPurple`, `syncing`, `isShowLocked()`, `currentEngine()`,
both `getBool` lambdas, etc. — exists and is correctly scoped where used),
but it has not been built or run. Flagging this clearly per your
CONTRIBUTING.md's testing guidance — happy to iterate on anything that
doesn't compile or behave as expected once you're able to build it.

🤖 Drafted with Claude Code + Codex, human-reviewed (source-only, not
build-verified per above).